### PR TITLE
Add ctrie to benchmarks

### DIFF
--- a/concurrent-hashtable.cabal
+++ b/concurrent-hashtable.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7834f6064f64bfa33fe2eafc0cbcb8225c1f11666c3c89039b710ba05476ed2e
+-- hash: 2f1effdb98db175cd144672aa00e90947cc8e3342ca2d7fa8d90d0dd7f1c6603
 
 name:           concurrent-hashtable
 version:        0.1.8
@@ -82,6 +82,7 @@ benchmark mainbench
     , concurrent-hashtable
     , containers >=0.6.0.1 && <1
     , criterion >=1.5.6.0 && <2
+    , ctrie
     , dictionary-type
     , hashable >=1.2.7.0 && <2
     , random >=1.1 && <2

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ benchmarks:
     - concurrent-hashtable
     - dictionary-type   # internal library used for benchmark
     - async  >= 2.2.2 && < 3
+    - ctrie
     - containers >= 0.6.0.1 && <1
     - criterion >= 1.5.6.0 && <2
     - unordered-containers >= 0.2.10.0 && < 1


### PR DESCRIPTION
While looking for concurrent hash tables in Haskell I found [ctrie](https://hackage.haskell.org/package/ctrie) (in addition to your package), so I thought I'd add it to your benchmarks.